### PR TITLE
Send post URL to custom login page

### DIFF
--- a/php/class.PublicAccess.php
+++ b/php/class.PublicAccess.php
@@ -71,7 +71,7 @@ class PublicAccess {
             $role_check          = array_diff( $all_roles, $mkdo_rcbr_roles );
 
 			if ( ! empty( $mkdo_rcbr_default_redirect ) ) {
-				$redirect_url = $mkdo_rcbr_default_redirect;
+				$redirect_url = $mkdo_rcbr_default_redirect . '?redirect_url=' . urlencode(get_the_permalink( $post->ID ));
 			}
 
 			// If the content is not a public override


### PR DESCRIPTION
Send the permalink of the original post to the custom page when restricted
content is accessed. This allows a custom login page to be created and
that page redirect back to the original content URL after login.
